### PR TITLE
[Update] 로그인 로직 수정 및 컬럼 CRUD 기능 개선

### DIFF
--- a/src/main/java/com/sparta/trelloproject/board/controller/BoardController.java
+++ b/src/main/java/com/sparta/trelloproject/board/controller/BoardController.java
@@ -6,82 +6,76 @@ import com.sparta.trelloproject.board.dto.BoardResponseDto;
 import com.sparta.trelloproject.board.service.BoardService;
 import com.sparta.trelloproject.common.api.ApiResponseDto;
 import com.sparta.trelloproject.common.security.UserDetailsImpl;
-import java.io.IOException;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class BoardController {
 
-  private final BoardService boardService;
+    private final BoardService boardService;
 
-  // 보드 생성
-  @PostMapping("/boards")
-  public ResponseEntity<ApiResponseDto> createBoard(
-      @AuthenticationPrincipal UserDetailsImpl userDetails,
-      @RequestBody BoardRequestDto boardRequestDto) throws IOException {
+    // 보드 생성
+    @PostMapping("/boards")
+    public ResponseEntity<ApiResponseDto> createBoard(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody BoardRequestDto boardRequestDto) throws IOException {
 
-    boardService.createBoard(userDetails, boardRequestDto);
+        boardService.createBoard(userDetails, boardRequestDto);
 
-    return ResponseEntity.ok().body(new ApiResponseDto("보드 생성 성공", HttpStatus.OK.value()));
-  }
+        return ResponseEntity.ok().body(new ApiResponseDto("보드 생성 성공", HttpStatus.OK.value()));
+    }
 
-  // 로그인사용자가 속한 보드 전체 조회 (본인생성 + 콜라보레이트권한있는 보드)
-  @GetMapping("/boards")
-  public List<BoardListResponseDto> getBoards(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    // 로그인사용자가 속한 보드 전체 조회 (본인생성 + 콜라보레이트권한있는 보드)
+    @GetMapping("/boards")
+    public List<BoardListResponseDto> getBoards(@AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-    return boardService.getBoards(userDetails);
-  }
+        return boardService.getBoards(userDetails);
+    }
 
-  // 보드 단건 조회
-  @GetMapping("/boards/{boardId}")
-  public BoardResponseDto getBoard(@PathVariable Long boardId) {
+    // 보드 단건 조회
+    @GetMapping("/boards/{boardId}")
+    public BoardResponseDto getBoard(@PathVariable Long boardId) {
 
-    return boardService.getBoard(boardId);
-  }
+        return boardService.getBoard(boardId);
+    }
 
-  // 보드 수정
-  @PutMapping("/boards/{boardId}")
-  public ResponseEntity<ApiResponseDto> updateBoard(
-      @AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long boardId,
-      @RequestBody BoardRequestDto boardRequestDto) throws IOException {
+    // 보드 수정
+    @PutMapping("/boards/{boardId}")
+    public ResponseEntity<ApiResponseDto> updateBoard(
+            @AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long boardId,
+            @RequestBody BoardRequestDto boardRequestDto) throws IOException {
 
-    boardService.updateBoard(userDetails, boardId, boardRequestDto);
+        boardService.updateBoard(userDetails, boardId, boardRequestDto);
 
-    return ResponseEntity.ok().body(new ApiResponseDto("보드 수정 성공", HttpStatus.OK.value()));
-  }
+        return ResponseEntity.ok().body(new ApiResponseDto("보드 수정 성공", HttpStatus.OK.value()));
+    }
 
-  // 보드 삭제
-  @DeleteMapping("/boards/{boardId}")
-  public ResponseEntity<ApiResponseDto> deleteBoard(
-      @AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long boardId) {
+    // 보드 삭제
+    @DeleteMapping("/boards/{boardId}")
+    public ResponseEntity<ApiResponseDto> deleteBoard(
+            @AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long boardId) {
 
-    boardService.deleteBoard(userDetails, boardId);
+        boardService.deleteBoard(userDetails, boardId);
 
-    return ResponseEntity.ok().body(new ApiResponseDto("보드 삭제 성공", HttpStatus.OK.value()));
-  }
+        return ResponseEntity.ok().body(new ApiResponseDto("보드 삭제 성공", HttpStatus.OK.value()));
+    }
 
-  // 보드 콜라보레이터 추가
-  @PostMapping("/boards/{boardId}/invite/{userId}")
-  public ResponseEntity<ApiResponseDto> inviteUser(
-      @AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long boardId,
-      @PathVariable Long userId) {
+    // 보드 콜라보레이터 추가
+    @PostMapping("/boards/{boardId}/invite/{userId}")
+    public ResponseEntity<ApiResponseDto> inviteUser(
+            @AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long boardId,
+            @PathVariable Long userId) {
 
-    boardService.inviteUser(userDetails, boardId, userId);
+        boardService.inviteUser(userDetails, boardId, userId);
 
-    return ResponseEntity.ok().body(new ApiResponseDto("콜라보레이터 추가 성공", HttpStatus.OK.value()));
-  }
+        return ResponseEntity.ok().body(new ApiResponseDto("콜라보레이터 추가 성공", HttpStatus.OK.value()));
+    }
 }

--- a/src/main/java/com/sparta/trelloproject/board/dto/BoardListResponseDto.java
+++ b/src/main/java/com/sparta/trelloproject/board/dto/BoardListResponseDto.java
@@ -6,13 +6,13 @@ import lombok.Getter;
 
 @Getter
 public class BoardListResponseDto {
-  private String boardName;
-  private String description;
-  private ColorEnum color;
+    private String boardName;
+    private String description;
+    private ColorEnum color;
 
-  public BoardListResponseDto(Board board) {
-    this.boardName = board.getBoardName();
-    this.description = board.getDescription();
-    this.color = board.getColor();
-  }
+    public BoardListResponseDto(Board board) {
+        this.boardName = board.getBoardName();
+        this.description = board.getDescription();
+        this.color = board.getColor();
+    }
 }

--- a/src/main/java/com/sparta/trelloproject/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/sparta/trelloproject/board/dto/BoardRequestDto.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 
 @Getter
 public class BoardRequestDto {
-  private String boardName;
-  private String description;
-  private ColorEnum color;
+    private String boardName;
+    private String description;
+    private ColorEnum color;
 
 }

--- a/src/main/java/com/sparta/trelloproject/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/sparta/trelloproject/board/dto/BoardResponseDto.java
@@ -2,30 +2,31 @@ package com.sparta.trelloproject.board.dto;
 
 import com.sparta.trelloproject.column.dto.ColumnResponseDto;
 import com.sparta.trelloproject.common.color.ColorEnum;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class BoardResponseDto {
 
-  private String boardName;
-  private String description;
-  private ColorEnum color;
-  private String ownerUser;
-  private List<CollaboraterResponseDto> collaboraters;
-  private List<ColumnResponseDto> columnList;
+    private String boardName;
+    private String description;
+    private ColorEnum color;
+    private String ownerUser;
+    private List<CollaboraterResponseDto> collaboraters;
+    private List<ColumnResponseDto> columnList;
 
-  @Builder
-  public BoardResponseDto(String boardName, String description, ColorEnum color, String ownerUser,
-      List<CollaboraterResponseDto> collaboraters,
-      List<ColumnResponseDto> columnList) {
-    this.boardName = boardName;
-    this.description = description;
-    this.color = color;
-    this.ownerUser = ownerUser;
-    this.collaboraters = collaboraters;
-    this.columnList = columnList;
-  }
+    @Builder
+    public BoardResponseDto(String boardName, String description, ColorEnum color, String ownerUser,
+                            List<CollaboraterResponseDto> collaboraters,
+                            List<ColumnResponseDto> columnList) {
+        this.boardName = boardName;
+        this.description = description;
+        this.color = color;
+        this.ownerUser = ownerUser;
+        this.collaboraters = collaboraters;
+        this.columnList = columnList;
+    }
 
 }

--- a/src/main/java/com/sparta/trelloproject/board/dto/CollaboraterResponseDto.java
+++ b/src/main/java/com/sparta/trelloproject/board/dto/CollaboraterResponseDto.java
@@ -5,9 +5,9 @@ import lombok.Getter;
 
 @Getter
 public class CollaboraterResponseDto {
-  private String collaboraterName;
+    private String collaboraterName;
 
-  public CollaboraterResponseDto(BoardUser boardUser) {
-    this.collaboraterName = boardUser.getCollaborateUser().getUserName();
-  }
+    public CollaboraterResponseDto(BoardUser boardUser) {
+        this.collaboraterName = boardUser.getCollaborateUser().getUserName();
+    }
 }

--- a/src/main/java/com/sparta/trelloproject/board/entity/Board.java
+++ b/src/main/java/com/sparta/trelloproject/board/entity/Board.java
@@ -2,70 +2,60 @@ package com.sparta.trelloproject.board.entity;
 
 import com.sparta.trelloproject.common.color.ColorEnum;
 import com.sparta.trelloproject.user.entity.User;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Board {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-  @Column(name = "board_name", nullable = false)
-  private String boardName;
+    @Column(name = "board_name", nullable = false)
+    private String boardName;
 
-  @Column
-  private String description;
+    @Column
+    private String description;
 
-  @Enumerated(EnumType.STRING)
-  private ColorEnum color;
+    @Enumerated(EnumType.STRING)
+    private ColorEnum color;
 
-  // 보드의 생성자(주인) 유저
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id")
-  private User user;
+    // 보드의 생성자(주인) 유저
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
-  @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
-  private List<BoardUser> boardUsers = new ArrayList<>();
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
+    private List<BoardUser> boardUsers = new ArrayList<>();
 
-  @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
-  private List<com.sparta.trelloproject.column.entity.Column> columns = new ArrayList<>();
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
+    private List<com.sparta.trelloproject.column.entity.Column> columns = new ArrayList<>();
 
-  @Builder
-  public Board(String boardName, String description, ColorEnum color, User user) {
-    this.boardName = boardName;
-    this.description = description;
-    this.color = color;
-    this.user = user;
-  }
+    @Builder
+    public Board(String boardName, String description, ColorEnum color, User user) {
+        this.boardName = boardName;
+        this.description = description;
+        this.color = color;
+        this.user = user;
+    }
 
-  public void update(String boardName, String description, ColorEnum color) {
-    this.boardName = boardName;
-    this.description = description;
-    this.color = color;
-  }
+    public void update(String boardName, String description, ColorEnum color) {
+        this.boardName = boardName;
+        this.description = description;
+        this.color = color;
+    }
 
-  public void addBaordUser(BoardUser boardUser) {
-    this.boardUsers.add(boardUser);
-  }
+    public void addBaordUser(BoardUser boardUser) {
+        this.boardUsers.add(boardUser);
+    }
 
 }

--- a/src/main/java/com/sparta/trelloproject/board/entity/BoardUser.java
+++ b/src/main/java/com/sparta/trelloproject/board/entity/BoardUser.java
@@ -1,13 +1,7 @@
 package com.sparta.trelloproject.board.entity;
 
 import com.sparta.trelloproject.user.entity.User;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,27 +11,27 @@ import lombok.NoArgsConstructor;
 @Getter
 public class BoardUser {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "board_user_id")
-  private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_user_id")
+    private Long id;
 
-  @ManyToOne
-  @JoinColumn(name = "owner_id", nullable = false)
-  User ownerUser;
+    @ManyToOne
+    @JoinColumn(name = "owner_id", nullable = false)
+    User ownerUser;
 
-  @ManyToOne
-  @JoinColumn(name = "collaborate_user_id", nullable = false)
-  User collaborateUser;
+    @ManyToOne
+    @JoinColumn(name = "collaborate_user_id", nullable = false)
+    User collaborateUser;
 
-  @ManyToOne
-  @JoinColumn(name = "board_id", nullable = false)
-  Board board;
+    @ManyToOne
+    @JoinColumn(name = "board_id", nullable = false)
+    Board board;
 
-  public BoardUser(User collaborateUser, Board board) {
-    this.ownerUser = board.getUser();
-    this.collaborateUser = collaborateUser;
-    this.board = board;
-    board.addBaordUser(this);
-  }
+    public BoardUser(User collaborateUser, Board board) {
+        this.ownerUser = board.getUser();
+        this.collaborateUser = collaborateUser;
+        this.board = board;
+        board.addBaordUser(this);
+    }
 }

--- a/src/main/java/com/sparta/trelloproject/board/repository/BoardRepository.java
+++ b/src/main/java/com/sparta/trelloproject/board/repository/BoardRepository.java
@@ -1,9 +1,10 @@
 package com.sparta.trelloproject.board.repository;
 
 import com.sparta.trelloproject.board.entity.Board;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BoardRepository extends JpaRepository<Board, Long> {
-  List<Board> findAllById(Long id);
+    List<Board> findAllById(Long id);
 }

--- a/src/main/java/com/sparta/trelloproject/board/repository/BoardUserRepository.java
+++ b/src/main/java/com/sparta/trelloproject/board/repository/BoardUserRepository.java
@@ -3,12 +3,15 @@ package com.sparta.trelloproject.board.repository;
 import com.sparta.trelloproject.board.entity.Board;
 import com.sparta.trelloproject.board.entity.BoardUser;
 import com.sparta.trelloproject.user.entity.User;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface BoardUserRepository extends JpaRepository<BoardUser, Long> {
 
-  List<BoardUser> findAllByCollaborateUser(User user);
-  List<BoardUser> findAllByCollaborateUserAndBoard(User collaboraterUser, Board board);
-  List<BoardUser> findAllByOwnerUserAndCollaborateUserAndBoard(User ownerUser, User collaboraterUser, Board board);
+    List<BoardUser> findAllByCollaborateUser(User user);
+
+    List<BoardUser> findAllByCollaborateUserAndBoard(User collaboraterUser, Board board);
+
+    List<BoardUser> findAllByOwnerUserAndCollaborateUserAndBoard(User ownerUser, User collaboraterUser, Board board);
 }

--- a/src/main/java/com/sparta/trelloproject/board/service/BoardService.java
+++ b/src/main/java/com/sparta/trelloproject/board/service/BoardService.java
@@ -14,147 +14,148 @@ import com.sparta.trelloproject.column.repository.ColumnRepository;
 import com.sparta.trelloproject.common.security.UserDetailsImpl;
 import com.sparta.trelloproject.user.entity.User;
 import com.sparta.trelloproject.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class BoardService {
 
-  private final BoardRepository boardRepository;
-  private final UserRepository userRepository;
-  private final BoardUserRepository boardUserRepository;
-  private final ColumnRepository columnRepository;
+    private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+    private final BoardUserRepository boardUserRepository;
+    private final ColumnRepository columnRepository;
 
-  // 보드 생성
-  @Transactional
-  public void createBoard(UserDetailsImpl userDetails, BoardRequestDto boardRequestDto)
-      throws IOException {
+    // 보드 생성
+    @Transactional
+    public void createBoard(UserDetailsImpl userDetails, BoardRequestDto boardRequestDto)
+            throws IOException {
 
-    Board board = Board.builder()
-        .boardName(boardRequestDto.getBoardName())
-        .description(boardRequestDto.getDescription())
-        .color(boardRequestDto.getColor())
-        .user(userDetails.getUser())
-        .build();
+        Board board = Board.builder()
+                .boardName(boardRequestDto.getBoardName())
+                .description(boardRequestDto.getDescription())
+                .color(boardRequestDto.getColor())
+                .user(userDetails.getUser())
+                .build();
 
-    boardRepository.save(board);
-  }
-
-  // 사용자가 속한 보드 전체조회
-  public List<BoardListResponseDto> getBoards(UserDetailsImpl userDetails) {
-    List<Board> allMyBoards = new ArrayList<>();
-
-    // 본인이 콜라보레이터 초대된 보드들 가져오기
-    List<Board> collaborateBoards = boardUserRepository.findAllByCollaborateUser(
-            userDetails.getUser()).stream()
-        .map(BoardUser::getBoard)
-        .collect(Collectors.toList());
-    for (Board collaborateBoard : collaborateBoards) {
-      allMyBoards.add(collaborateBoard);
+        boardRepository.save(board);
     }
 
-    // 본인이 만든 보드 가져오기
-    List<Board> myBoards = boardRepository.findAllById(userDetails.getUser().getId());
-    for (Board myBoard : myBoards) {
-      allMyBoards.add(myBoard);
+    // 사용자가 속한 보드 전체조회
+    public List<BoardListResponseDto> getBoards(UserDetailsImpl userDetails) {
+        List<Board> allMyBoards = new ArrayList<>();
+
+        // 본인이 콜라보레이터 초대된 보드들 가져오기
+        List<Board> collaborateBoards = boardUserRepository.findAllByCollaborateUser(
+                        userDetails.getUser()).stream()
+                .map(BoardUser::getBoard)
+                .collect(Collectors.toList());
+        for (Board collaborateBoard : collaborateBoards) {
+            allMyBoards.add(collaborateBoard);
+        }
+
+        // 본인이 만든 보드 가져오기
+        List<Board> myBoards = boardRepository.findAllById(userDetails.getUser().getId());
+        for (Board myBoard : myBoards) {
+            allMyBoards.add(myBoard);
+        }
+
+        return allMyBoards.stream()
+                .map(BoardListResponseDto::new)
+                .collect(Collectors.toList());
     }
 
-    return allMyBoards.stream()
-        .map(BoardListResponseDto::new)
-        .collect(Collectors.toList());
-  }
+    // 보드 단건조회
+    // + 해당 보드의 생성자,콜라보레이터 함께 조회
+    public BoardResponseDto getBoard(Long boardId) {
+        Board board = boardRepository.findById(boardId).orElseThrow(() ->
+                new IllegalArgumentException("보드를 찾을 수 없습니다."));
 
-  // 보드 단건조회
-  // + 해당 보드의 생성자,콜라보레이터 함께 조회
-  public BoardResponseDto getBoard(Long boardId) {
-    Board board = boardRepository.findById(boardId).orElseThrow(() ->
-        new IllegalArgumentException("보드를 찾을 수 없습니다."));
-
-    BoardResponseDto boardResponseDto = BoardResponseDto.builder()
-        .boardName(board.getBoardName())
-        .description(board.getDescription())
-        .color(board.getColor())
-        .ownerUser(board.getUser().getUserName())
-        .collaboraters(board.getBoardUsers().stream()
-            .map(CollaboraterResponseDto::new)
-            .collect(Collectors.toList()))
-        .columnList(columnRepository.findAllByBoard(board).stream()
-            .map(ColumnResponseDto::new)
-            .collect(Collectors.toList()))
-        .build();
-    return boardResponseDto;
-  }
-
-  // 보드 수정
-  @Transactional
-  public void updateBoard(UserDetailsImpl userDetails, Long boardId,
-      BoardRequestDto boardRequestDto) throws IOException {
-    Board board = boardRepository.findById(boardId).orElseThrow(() ->
-        new IllegalArgumentException("보드를 찾을 수 없습니다."));
-
-    // 보드 생성자만 수정 가능하도록
-    if (!board.getUser().getId().equals(userDetails.getUser().getId())) {
-      throw new IllegalArgumentException("보드 생성자만 수정할 수 있습니다.");
+        BoardResponseDto boardResponseDto = BoardResponseDto.builder()
+                .boardName(board.getBoardName())
+                .description(board.getDescription())
+                .color(board.getColor())
+                .ownerUser(board.getUser().getUserName())
+                .collaboraters(board.getBoardUsers().stream()
+                        .map(CollaboraterResponseDto::new)
+                        .collect(Collectors.toList()))
+                .columnList(columnRepository.findAllByBoard(board).stream()
+                        .map(ColumnResponseDto::new)
+                        .collect(Collectors.toList()))
+                .build();
+        return boardResponseDto;
     }
 
-    board.update(boardRequestDto.getBoardName(),
-        boardRequestDto.getDescription(),
-        boardRequestDto.getColor());
+    // 보드 수정
+    @Transactional
+    public void updateBoard(UserDetailsImpl userDetails, Long boardId,
+                            BoardRequestDto boardRequestDto) throws IOException {
+        Board board = boardRepository.findById(boardId).orElseThrow(() ->
+                new IllegalArgumentException("보드를 찾을 수 없습니다."));
 
-    boardRepository.save(board);
-  }
+        // 보드 생성자만 수정 가능하도록
+        if (!board.getUser().getId().equals(userDetails.getUser().getId())) {
+            throw new IllegalArgumentException("보드 생성자만 수정할 수 있습니다.");
+        }
 
-  // 보드 삭제
-  @Transactional
-  public void deleteBoard(UserDetailsImpl userDetails, Long boardId) {
-    Board board = boardRepository.findById(boardId).orElseThrow(() ->
-        new IllegalArgumentException("보드를 찾을 수 없습니다."));
+        board.update(boardRequestDto.getBoardName(),
+                boardRequestDto.getDescription(),
+                boardRequestDto.getColor());
 
-    // 보드 생성자만 삭제 가능하도록
-    if (!board.getUser().getId().equals(userDetails.getUser().getId())) {
-      throw new IllegalArgumentException("보드 생성자만 삭제할 수 있습니다.");
+        boardRepository.save(board);
     }
 
-    boardRepository.delete(board);
-  }
+    // 보드 삭제
+    @Transactional
+    public void deleteBoard(UserDetailsImpl userDetails, Long boardId) {
+        Board board = boardRepository.findById(boardId).orElseThrow(() ->
+                new IllegalArgumentException("보드를 찾을 수 없습니다."));
 
-  // 보드에 콜라보레이터 초대
-  @Transactional
-  public void inviteUser(UserDetailsImpl userDetails, Long boardId, Long userId) {
+        // 보드 생성자만 삭제 가능하도록
+        if (!board.getUser().getId().equals(userDetails.getUser().getId())) {
+            throw new IllegalArgumentException("보드 생성자만 삭제할 수 있습니다.");
+        }
 
-    Board board = boardRepository.findById(boardId).orElseThrow(() ->
-        new IllegalArgumentException("보드를 찾을 수 없습니다."));
-
-    // 보드의 작성자만 초대가능하도록 예외처리
-    if (board.getUser().getId() != userDetails.getUser().getId()) {
-      throw new IllegalArgumentException("보드 생성자만 초대 가능합니다.");
+        boardRepository.delete(board);
     }
 
-    // 콜라보레이터 초대할 사용자
-    User user = userRepository.findById(userId).orElseThrow(() ->
-        new IllegalArgumentException("회원을 찾을 수 없습니다."));
+    // 보드에 콜라보레이터 초대
+    @Transactional
+    public void inviteUser(UserDetailsImpl userDetails, Long boardId, Long userId) {
 
-    // 본인을 콜라보레이터로 지정시 예외처리
-    if (user.getId().equals(userDetails.getUser().getId())) {
-      throw new IllegalArgumentException("본인은 추가할 필요 없습니다.");
+        Board board = boardRepository.findById(boardId).orElseThrow(() ->
+                new IllegalArgumentException("보드를 찾을 수 없습니다."));
+
+        // 보드의 작성자만 초대가능하도록 예외처리
+        if (board.getUser().getId() != userDetails.getUser().getId()) {
+            throw new IllegalArgumentException("보드 생성자만 초대 가능합니다.");
+        }
+
+        // 콜라보레이터 초대할 사용자
+        User user = userRepository.findById(userId).orElseThrow(() ->
+                new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+        // 본인을 콜라보레이터로 지정시 예외처리
+        if (user.getId().equals(userDetails.getUser().getId())) {
+            throw new IllegalArgumentException("본인은 추가할 필요 없습니다.");
+        }
+
+        if (!boardUserRepository
+                .findAllByOwnerUserAndCollaborateUserAndBoard(board.getUser(), user, board)
+                .isEmpty()) {
+            throw new IllegalArgumentException("이미 초대하셨습니다.");
+        }
+
+        BoardUser boardUser = new BoardUser(user, board);
+
+        boardUserRepository.save(boardUser);
+
     }
-
-    if (!boardUserRepository
-        .findAllByOwnerUserAndCollaborateUserAndBoard(board.getUser(), user, board)
-        .isEmpty()) {
-      throw new IllegalArgumentException("이미 초대하셨습니다.");
-    }
-
-    BoardUser boardUser = new BoardUser(user, board);
-
-    boardUserRepository.save(boardUser);
-
-  }
 }

--- a/src/main/java/com/sparta/trelloproject/column/controller/ColumnController.java
+++ b/src/main/java/com/sparta/trelloproject/column/controller/ColumnController.java
@@ -1,5 +1,6 @@
 package com.sparta.trelloproject.column.controller;
 
+import com.sparta.trelloproject.column.dto.ColumnMoveDto;
 import com.sparta.trelloproject.column.dto.ColumnRequestDto;
 import com.sparta.trelloproject.column.dto.ColumnResponseDto;
 import com.sparta.trelloproject.column.service.ColumnService;
@@ -19,6 +20,7 @@ import java.util.List;
 public class ColumnController {
     private final ColumnService columnService;
 
+    // 컬럼 생성
     @PostMapping("/{boardId}/columns")
     public ResponseEntity<ApiResponseDto> createColumn(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                        @PathVariable("boardId") Long boardId,
@@ -27,6 +29,7 @@ public class ColumnController {
         return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponseDto("컬럼 생성 완료", HttpStatus.CREATED.value()));
     }
 
+    // 본인이 속한 보드의 컬럼 조회
     @GetMapping("/{boardId}/columns")
     public ResponseEntity<List<ColumnResponseDto>> getColumn(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                              @PathVariable("boardId") Long boardId) {
@@ -34,6 +37,7 @@ public class ColumnController {
         return ResponseEntity.ok().body(columnList);
     }
 
+    // 컬럼 이름 수정
     @PutMapping("/{boardId}/columns/{columnId}")
     public ResponseEntity<ApiResponseDto> updateColumn(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                        @RequestBody ColumnRequestDto requestDto,
@@ -43,11 +47,21 @@ public class ColumnController {
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponseDto("컬럼 수정 완료", HttpStatus.OK.value()));
     }
 
+    // 컬럼 삭제
     @DeleteMapping("/{boardId}/columns/{columnId}")
     public ResponseEntity<ApiResponseDto> deleteColumn(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                        @PathVariable("boardId") Long boardId,
                                                        @PathVariable("columnId") Long columnId) {
         columnService.deleteColumn(userDetails.getUser(), boardId, columnId);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponseDto("컬럼 삭제 완료", HttpStatus.OK.value()));
+    }
+
+    @PutMapping("/{boardId}/columns/{columnId}/order")
+    public ResponseEntity<List<ColumnResponseDto>> moveColumn(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                              @PathVariable("boardId") Long boardId,
+                                                              @PathVariable("columnId") Long columnId,
+                                                              @RequestBody ColumnMoveDto moveDto) {
+        List<ColumnResponseDto> results = columnService.moveColumn(userDetails.getUser(), boardId, columnId, moveDto);
+        return ResponseEntity.ok().body(results);
     }
 }

--- a/src/main/java/com/sparta/trelloproject/column/controller/ColumnController.java
+++ b/src/main/java/com/sparta/trelloproject/column/controller/ColumnController.java
@@ -56,12 +56,11 @@ public class ColumnController {
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponseDto("컬럼 삭제 완료", HttpStatus.OK.value()));
     }
 
-    @PutMapping("/{boardId}/columns/{columnId}/order")
+    @PutMapping("/{boardId}/columns/order")
     public ResponseEntity<List<ColumnResponseDto>> moveColumn(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                               @PathVariable("boardId") Long boardId,
-                                                              @PathVariable("columnId") Long columnId,
                                                               @RequestBody ColumnMoveDto moveDto) {
-        List<ColumnResponseDto> results = columnService.moveColumn(userDetails.getUser(), boardId, columnId, moveDto);
+        List<ColumnResponseDto> results = columnService.moveColumn(userDetails.getUser(), boardId, moveDto);
         return ResponseEntity.ok().body(results);
     }
 }

--- a/src/main/java/com/sparta/trelloproject/column/controller/ColumnController.java
+++ b/src/main/java/com/sparta/trelloproject/column/controller/ColumnController.java
@@ -28,8 +28,9 @@ public class ColumnController {
     }
 
     @GetMapping("/{boardId}/columns")
-    public ResponseEntity<List<ColumnResponseDto>> getColumn(@PathVariable("boardId") Long boardId) {
-        List<ColumnResponseDto> columnList = columnService.getColumn();
+    public ResponseEntity<List<ColumnResponseDto>> getColumn(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                             @PathVariable("boardId") Long boardId) {
+        List<ColumnResponseDto> columnList = columnService.getColumn(userDetails.getUser(), boardId);
         return ResponseEntity.ok().body(columnList);
     }
 

--- a/src/main/java/com/sparta/trelloproject/column/dto/ColumnMoveDto.java
+++ b/src/main/java/com/sparta/trelloproject/column/dto/ColumnMoveDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 public class ColumnMoveDto {
     @NotBlank
-    private Long selectBoardId;
+    private int selectColumn;
 
     @NotBlank
     private int selectIndex;

--- a/src/main/java/com/sparta/trelloproject/column/dto/ColumnMoveDto.java
+++ b/src/main/java/com/sparta/trelloproject/column/dto/ColumnMoveDto.java
@@ -1,0 +1,13 @@
+package com.sparta.trelloproject.column.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class ColumnMoveDto {
+    @NotBlank
+    private Long selectBoardId;
+
+    @NotBlank
+    private int selectIndex;
+}

--- a/src/main/java/com/sparta/trelloproject/column/dto/ColumnResponseDto.java
+++ b/src/main/java/com/sparta/trelloproject/column/dto/ColumnResponseDto.java
@@ -11,14 +11,12 @@ public class ColumnResponseDto {
     private Long boardId;
     private String userName;
     private String columnName;
-    private int position;
 //    private List<CardResponseDto> cardList;
 
     public ColumnResponseDto(Column column) {
         this.columnName = column.getColumnName();
         this.boardId = column.getBoard().getId();
         this.userName = column.getUser().getUserName();
-        this.position = column.getPosition();
 //        this.cardList = column.getCardList().stream()
 //                .map(ColumnResponseDto::new)
 //                .sorted(Comparator.comparing(ColumnResponseDto::getCreateAt))

--- a/src/main/java/com/sparta/trelloproject/column/dto/ColumnResponseDto.java
+++ b/src/main/java/com/sparta/trelloproject/column/dto/ColumnResponseDto.java
@@ -9,16 +9,16 @@ import lombok.Setter;
 @Setter
 public class ColumnResponseDto {
     private Long boardId;
-    private Long columnId;
     private String userName;
     private String columnName;
+    private int position;
 //    private List<CardResponseDto> cardList;
 
     public ColumnResponseDto(Column column) {
         this.columnName = column.getColumnName();
         this.boardId = column.getBoard().getId();
         this.userName = column.getUser().getUserName();
-        this.columnId = column.getId();
+        this.position = column.getPosition();
 //        this.cardList = column.getCardList().stream()
 //                .map(ColumnResponseDto::new)
 //                .sorted(Comparator.comparing(ColumnResponseDto::getCreateAt))

--- a/src/main/java/com/sparta/trelloproject/column/dto/ColumnResponseDto.java
+++ b/src/main/java/com/sparta/trelloproject/column/dto/ColumnResponseDto.java
@@ -1,19 +1,24 @@
 package com.sparta.trelloproject.column.dto;
 
 import com.sparta.trelloproject.column.entity.Column;
+import com.sparta.trelloproject.user.entity.User;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class ColumnResponseDto {
-    private String columnName;
     private Long boardId;
+    private Long columnId;
+    private String userName;
+    private String columnName;
 //    private List<CardResponseDto> cardList;
 
     public ColumnResponseDto(Column column) {
         this.columnName = column.getColumnName();
         this.boardId = column.getBoard().getId();
+        this.userName = column.getUser().getUserName();
+        this.columnId = column.getId();
 //        this.cardList = column.getCardList().stream()
 //                .map(ColumnResponseDto::new)
 //                .sorted(Comparator.comparing(ColumnResponseDto::getCreateAt))

--- a/src/main/java/com/sparta/trelloproject/column/entity/Column.java
+++ b/src/main/java/com/sparta/trelloproject/column/entity/Column.java
@@ -43,8 +43,7 @@ public class Column {
         this.columnName = requestDto.getColumnName();
     }
 
-    public void moveColumn(Board board, int position) {
-        this.board = board;
+    public void moveColumn(int position) {
         this.position = position;
     }
 }

--- a/src/main/java/com/sparta/trelloproject/column/entity/Column.java
+++ b/src/main/java/com/sparta/trelloproject/column/entity/Column.java
@@ -19,6 +19,8 @@ public class Column {
     @jakarta.persistence.Column
     private String columnName;
 
+    private int position;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id")
     private Board board;
@@ -30,13 +32,19 @@ public class Column {
 //    @OneToMany(mappedBy = "column", cascade = CascadeType.REMOVE)
 //    private List<Card> cardList = new ArrayList<>();
 
-    public Column(String columnName, Board board, User user) {
+    public Column(String columnName, Board board, User user, int position) {
         this.columnName = columnName;
         this.board = board;
         this.user = user;
+        this.position = position;
     }
 
     public void update(ColumnRequestDto requestDto) {
         this.columnName = requestDto.getColumnName();
+    }
+
+    public void moveColumn(Board board, int position) {
+        this.board = board;
+        this.position = position;
     }
 }

--- a/src/main/java/com/sparta/trelloproject/column/entity/Column.java
+++ b/src/main/java/com/sparta/trelloproject/column/entity/Column.java
@@ -1,12 +1,9 @@
 package com.sparta.trelloproject.column.entity;
 
 import com.sparta.trelloproject.board.entity.Board;
-import com.sparta.trelloproject.card.entity.Card;
 import com.sparta.trelloproject.column.dto.ColumnRequestDto;
 import com.sparta.trelloproject.user.entity.User;
 import jakarta.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/sparta/trelloproject/column/repository/ColumnRepository.java
+++ b/src/main/java/com/sparta/trelloproject/column/repository/ColumnRepository.java
@@ -11,4 +11,6 @@ public interface ColumnRepository extends JpaRepository<Column, Long> {
     Optional<Column> findByBoardIdAndId(Long boardId, Long ColumnId);
 
     List<Column> findAllByBoard(Board board);
+
+    List<Column> findAllByBoardIdOrderByPositionAsc(Long boardId);
 }

--- a/src/main/java/com/sparta/trelloproject/column/repository/ColumnRepository.java
+++ b/src/main/java/com/sparta/trelloproject/column/repository/ColumnRepository.java
@@ -2,9 +2,9 @@ package com.sparta.trelloproject.column.repository;
 
 import com.sparta.trelloproject.board.entity.Board;
 import com.sparta.trelloproject.column.entity.Column;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ColumnRepository extends JpaRepository<Column, Long> {

--- a/src/main/java/com/sparta/trelloproject/column/service/ColumnService.java
+++ b/src/main/java/com/sparta/trelloproject/column/service/ColumnService.java
@@ -8,74 +8,84 @@ import com.sparta.trelloproject.column.dto.ColumnResponseDto;
 import com.sparta.trelloproject.column.entity.Column;
 import com.sparta.trelloproject.column.repository.ColumnRepository;
 import com.sparta.trelloproject.user.entity.User;
-import com.sparta.trelloproject.user.entity.UserRoleEnum;
-import java.util.List;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ColumnService {
 
-  private final ColumnRepository columnRepository;
-  private final BoardRepository boardRepository;
-  private final BoardUserRepository boardUserRepository;
+    private final ColumnRepository columnRepository;
+    private final BoardRepository boardRepository;
+    private final BoardUserRepository boardUserRepository;
 
-  @Transactional
-  public void createColumn(User user, Long boardId, ColumnRequestDto requestDto) {
-    Board board = boardRepository.findById(boardId)
-        .orElseThrow(() -> new NullPointerException("선택한 Board 가 존재하지 않습니다. boardId : " + boardId));
+    @Transactional
+    public void createColumn(User user, Long boardId, ColumnRequestDto requestDto) {
+        Board board = findBoard(boardId);
 
-    // 보드생성자, 콜라보레이터만 생성가능
-    if (checkOwnerCollaborater(user, board)) {
-      throw new IllegalArgumentException("컬럼생성 권한이 없습니다.");
+        // 보드생성자, 콜라보레이터만 생성가능
+        if (checkOwnerCollaborater(user, board)) {
+            throw new IllegalArgumentException("컬럼 생성 권한이 없습니다.");
+        }
+
+        Column column = new Column(requestDto.getColumnName(), board, user);
+
+        columnRepository.save(column);
     }
 
-    Column column = new Column(requestDto.getColumnName(), board, user);
+    @Transactional(readOnly = true)
+    public List<ColumnResponseDto> getColumn(User user, Long boardId) {
+        Board board = findBoard(boardId);
 
-    columnRepository.save(column);
-  }
-
-  @Transactional(readOnly = true)
-  public List<ColumnResponseDto> getColumn() {
-    return columnRepository.findAll().stream().map(ColumnResponseDto::new)
-        .collect(Collectors.toList());
-  }
-
-  @Transactional
-  public void updateColumn(User user, ColumnRequestDto requestDto, Long boardId, Long columnId) {
-    Column column = columnRepository.findByBoardIdAndId(boardId, columnId).orElseThrow(
-        () -> new NullPointerException(
-            "선택한 Column 이 존재하지 않습니다. boardId : " + boardId + "columnId : " + columnId));
-
-    if (!(user.getRole().equals(UserRoleEnum.ADMIN) || column.getUser().getId().equals(user.getId()))) {
-      throw new RejectedExecutionException("작성자, 관리자만 수정할 수 있습니다.");
+        if (checkOwnerCollaborater(user, board)) {
+            throw new IllegalArgumentException("컬럼 조회 권한이 없습니다.");
+        }
+        return columnRepository.findAllByBoard(board).stream().map(ColumnResponseDto::new)
+                .collect(Collectors.toList());
     }
 
-    column.update(requestDto);
-  }
+    @Transactional
+    public void updateColumn(User user, ColumnRequestDto requestDto, Long boardId, Long columnId) {
+        Board board = findBoard(boardId);
+        Column column = findColumn(boardId, columnId);
 
-  @Transactional
-  public void deleteColumn(User user, Long boardId, Long columnId) {
-    Column column = columnRepository.findByBoardIdAndId(boardId, columnId).orElseThrow(
-        () -> new NullPointerException(
-            "선택한 Column 이 존재하지 않습니다. boardId : " + boardId + "columnId : " + columnId));
+        if (checkOwnerCollaborater(user, board)) {
+            throw new IllegalArgumentException("컬럼 수정 권한이 없습니다.");
+        }
 
-    if (!(user.getRole().equals(UserRoleEnum.ADMIN) || column.getUser().getId().equals(user.getId()))) {
-      throw new RejectedExecutionException("작성자, 관리자만 삭제할 수 있습니다.");
+        column.update(requestDto);
     }
 
-    columnRepository.delete(column);
-  }
+    @Transactional
+    public void deleteColumn(User user, Long boardId, Long columnId) {
+        Board board = findBoard(boardId);
+        Column column = findColumn(boardId, columnId);
 
-  // 컬럼 변경 권한 체크
-  private boolean checkOwnerCollaborater(User user, Board board) {
-    boolean result = boardUserRepository.findAllByCollaborateUserAndBoard(user, board).isEmpty()
-        && board.getUser().getId() != user.getId(); // 콜라보레이터에 해당유저 없고 보드생성자도 아닐경우 true.
-      return result;
+        if (checkOwnerCollaborater(user, board)) {
+            throw new IllegalArgumentException("컬럼 수정 권한이 없습니다.");
+        }
+
+        columnRepository.delete(column);
     }
 
-  }
+    // 컬럼 변경 권한 체크
+    private boolean checkOwnerCollaborater(User user, Board board) {
+        boolean result = boardUserRepository.findAllByCollaborateUserAndBoard(user, board).isEmpty()
+                && board.getUser().getId() != user.getId(); // 콜라보레이터에 해당유저 없고 보드생성자도 아닐경우 true.
+        return result;
+    }
+
+    private Board findBoard(Long boardId) {
+        return boardRepository.findById(boardId).orElseThrow(
+                () -> new IllegalArgumentException("선택한 Board 가 존재하지 않습니다. boardId : " + boardId));
+    }
+
+    private Column findColumn(Long boardId, Long columnId) {
+        return columnRepository.findByBoardIdAndId(boardId, columnId).orElseThrow(
+                () -> new IllegalArgumentException("선택한 Column 이 존재하지 않습니다. boardId : " + boardId + ", columnId : " + columnId));
+    }
+}

--- a/src/main/java/com/sparta/trelloproject/column/service/ColumnService.java
+++ b/src/main/java/com/sparta/trelloproject/column/service/ColumnService.java
@@ -3,6 +3,7 @@ package com.sparta.trelloproject.column.service;
 import com.sparta.trelloproject.board.entity.Board;
 import com.sparta.trelloproject.board.repository.BoardRepository;
 import com.sparta.trelloproject.board.repository.BoardUserRepository;
+import com.sparta.trelloproject.column.dto.ColumnMoveDto;
 import com.sparta.trelloproject.column.dto.ColumnRequestDto;
 import com.sparta.trelloproject.column.dto.ColumnResponseDto;
 import com.sparta.trelloproject.column.entity.Column;
@@ -32,7 +33,10 @@ public class ColumnService {
             throw new IllegalArgumentException("컬럼 생성 권한이 없습니다.");
         }
 
-        Column column = new Column(requestDto.getColumnName(), board, user);
+        // position => 1024 씩 증가
+        int position = (board.getColumns().size() != 0) ? (board.getColumns().size() +1) * 1024 : 1024;
+
+        Column column = new Column(requestDto.getColumnName(), board, user, position);
 
         columnRepository.save(column);
     }
@@ -72,7 +76,42 @@ public class ColumnService {
         columnRepository.delete(column);
     }
 
-    // 컬럼 변경 권한 체크
+    @Transactional
+    public List<ColumnResponseDto> moveColumn(User user, Long boardId, Long columnId, ColumnMoveDto moveDto) {
+        Board board = findBoard(boardId);
+
+        if (checkOwnerCollaborater(user, board)) {
+            throw new IllegalArgumentException("해당 보드의 권한이 없습니다.");
+        }
+
+        // 이동시킬 보드
+        Board selectBoard = findBoard(moveDto.getSelectBoardId());
+        if (checkOwnerCollaborater(user, selectBoard)) {
+            throw new IllegalArgumentException("해당 보드의 권한이 없습니다.");
+        }
+
+        // 이동시킬 컬럼
+        Column currentColumn = findColumn(boardId, columnId);
+        // selectPosition = 컬럼을 이동시킬 위치
+        Column selectColumn = selectBoard.getColumns().get(moveDto.getSelectIndex()-1);
+        int selectPosition = selectColumn.getPosition();
+
+        // 위치 순으로 정렬된 컬럼
+        List<Column> sortedColumnList = columnRepository.findAllByBoardIdOrderByPositionAsc(selectBoard.getId());
+
+        // selectColumn 앞 혹은 뒤 position
+        int aroundPosition;
+        aroundPosition = getAroundPosition(moveDto, sortedColumnList);
+
+        // 이동
+        move(selectBoard, currentColumn, selectPosition, aroundPosition);
+
+        return columnRepository.findAllByBoardIdOrderByPositionAsc(boardId).stream()
+                .map(ColumnResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+    // 컬럼 권한 체크
     private boolean checkOwnerCollaborater(User user, Board board) {
         boolean result = boardUserRepository.findAllByCollaborateUserAndBoard(user, board).isEmpty()
                 && board.getUser().getId() != user.getId(); // 콜라보레이터에 해당유저 없고 보드생성자도 아닐경우 true.
@@ -87,5 +126,25 @@ public class ColumnService {
     private Column findColumn(Long boardId, Long columnId) {
         return columnRepository.findByBoardIdAndId(boardId, columnId).orElseThrow(
                 () -> new IllegalArgumentException("선택한 Column 이 존재하지 않습니다. boardId : " + boardId + ", columnId : " + columnId));
+    }
+
+    private void move(Board selectBoard, Column currentColumn, int selectPosition, int aroundPosition) {
+        int movePosition = (selectPosition + aroundPosition) / 2 ;
+        currentColumn.moveColumn(selectBoard, movePosition);
+    }
+
+    private int getAroundPosition(ColumnMoveDto moveDto, List<Column> sortedColumnList) {
+        int aroundPosition;
+        if (moveDto.getSelectIndex() >= sortedColumnList.size() -1) {
+            aroundPosition = sortedColumnList.get(sortedColumnList.size() -1).getPosition() + 1024;
+        } else if (moveDto.getSelectIndex() == 0) {
+            int nextPosition = sortedColumnList.get(1).getPosition();
+            aroundPosition = Math.min(nextPosition - 1024, 0);
+        } else {
+            int prevPosition = sortedColumnList.get(moveDto.getSelectIndex() - 1).getPosition();
+            int nextPosition = sortedColumnList.get(moveDto.getSelectIndex() + 1).getPosition();
+            aroundPosition = (prevPosition + nextPosition) / 2;
+        }
+        return aroundPosition;
     }
 }

--- a/src/main/java/com/sparta/trelloproject/common/advice/GlobalControllerAdvice.java
+++ b/src/main/java/com/sparta/trelloproject/common/advice/GlobalControllerAdvice.java
@@ -4,6 +4,7 @@ import com.sparta.trelloproject.common.api.ApiResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -42,5 +43,10 @@ public class GlobalControllerAdvice {
         return new ResponseEntity<>(apiResponseDto, HttpStatus.BAD_REQUEST);
     }
 
-    //
+    // 토큰 만료시
+    @ExceptionHandler({UsernameNotFoundException.class})
+    public ResponseEntity<ApiResponseDto> handleException(UsernameNotFoundException ex) {
+        ApiResponseDto apiResponseDto = new ApiResponseDto(ex.getMessage(), HttpStatus.UNAUTHORIZED.value());
+        return new ResponseEntity<>(apiResponseDto, HttpStatus.UNAUTHORIZED);
+    }
 }

--- a/src/main/java/com/sparta/trelloproject/common/advice/GlobalControllerAdvice.java
+++ b/src/main/java/com/sparta/trelloproject/common/advice/GlobalControllerAdvice.java
@@ -1,0 +1,46 @@
+package com.sparta.trelloproject.common.advice;
+
+import com.sparta.trelloproject.common.api.ApiResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Objects;
+import java.util.concurrent.RejectedExecutionException;
+
+@RestControllerAdvice
+public class GlobalControllerAdvice {
+
+    // SignupRequestDto 의 Pattern Annotation 예외 처리
+    @ExceptionHandler({MethodArgumentNotValidException.class})
+    public ResponseEntity<ApiResponseDto> handleException(MethodArgumentNotValidException ex) {
+        ApiResponseDto apiResponseDto = new ApiResponseDto(Objects.requireNonNull(ex.getFieldError()).getDefaultMessage(), HttpStatus.BAD_REQUEST.value());
+        return new ResponseEntity<>(apiResponseDto, HttpStatus.BAD_REQUEST);
+    }
+
+    // 프로젝트 전반적인 IllegalArgumentException 의 예외 처리(포스트맨에서 실습할 때 활성화)
+    @ExceptionHandler({IllegalArgumentException.class})
+    public ResponseEntity<ApiResponseDto> handleException(IllegalArgumentException ex) {
+        ApiResponseDto apiResponseDto = new ApiResponseDto(ex.getMessage(), HttpStatus.BAD_REQUEST.value());
+        return new ResponseEntity<>(apiResponseDto, HttpStatus.BAD_REQUEST);
+    }
+
+    // 작성자 or Admin 이 아닌 경우
+    @ExceptionHandler({RejectedExecutionException.class})
+    public ResponseEntity<ApiResponseDto> handleException(RejectedExecutionException ex) {
+        ApiResponseDto apiResponseDto = new ApiResponseDto(ex.getMessage(), HttpStatus.FORBIDDEN.value());
+        return new ResponseEntity<>(apiResponseDto, HttpStatus.FORBIDDEN);
+    }
+
+    // enum 클래스 내의 값이 아닌 다른 값을 입력할 경우
+    @ExceptionHandler({HttpMessageNotReadableException.class})
+    public ResponseEntity<ApiResponseDto> handleException(HttpMessageNotReadableException ex) {
+        ApiResponseDto apiResponseDto = new ApiResponseDto("지정된 색만 입력할 수 있습니다.", HttpStatus.BAD_REQUEST.value());
+        return new ResponseEntity<>(apiResponseDto, HttpStatus.BAD_REQUEST);
+    }
+
+    //
+}

--- a/src/main/java/com/sparta/trelloproject/common/advice/GlobalControllerAdvice.java
+++ b/src/main/java/com/sparta/trelloproject/common/advice/GlobalControllerAdvice.java
@@ -42,11 +42,4 @@ public class GlobalControllerAdvice {
         ApiResponseDto apiResponseDto = new ApiResponseDto("지정된 색만 입력할 수 있습니다.", HttpStatus.BAD_REQUEST.value());
         return new ResponseEntity<>(apiResponseDto, HttpStatus.BAD_REQUEST);
     }
-
-    // 토큰 만료시
-    @ExceptionHandler({UsernameNotFoundException.class})
-    public ResponseEntity<ApiResponseDto> handleException(UsernameNotFoundException ex) {
-        ApiResponseDto apiResponseDto = new ApiResponseDto(ex.getMessage(), HttpStatus.UNAUTHORIZED.value());
-        return new ResponseEntity<>(apiResponseDto, HttpStatus.UNAUTHORIZED);
-    }
 }

--- a/src/main/java/com/sparta/trelloproject/common/color/ColorEnum.java
+++ b/src/main/java/com/sparta/trelloproject/common/color/ColorEnum.java
@@ -1,5 +1,5 @@
 package com.sparta.trelloproject.common.color;
 
 public enum ColorEnum {
-  RED, BLUE, GREEN, WHITE, BLACK, YELLOW, ORANGE, NAVY, PURPLE
+    RED, BLUE, GREEN, WHITE, BLACK, YELLOW, ORANGE, NAVY, PURPLE
 }

--- a/src/main/java/com/sparta/trelloproject/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/sparta/trelloproject/common/config/WebSecurityConfig.java
@@ -1,6 +1,6 @@
 package com.sparta.trelloproject.common.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.trelloproject.common.jwt.JwtAuthenticationFilter;
 import com.sparta.trelloproject.common.jwt.JwtAuthorizationFilter;
 import com.sparta.trelloproject.common.jwt.JwtUtil;
 import com.sparta.trelloproject.common.security.UserDetailsServiceImpl;
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -30,7 +29,7 @@ public class WebSecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final UserDetailsServiceImpl userDetailsService;
-    private final ObjectMapper objectMapper;
+    private final AuthenticationConfiguration authenticationConfiguration;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -43,8 +42,15 @@ public class WebSecurityConfig {
     }
 
     @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil);
+        filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
+        return filter;
+    }
+
+    @Bean
     public JwtAuthorizationFilter jwtAuthorizationFilter() {
-        return new JwtAuthorizationFilter(jwtUtil, userDetailsService, objectMapper);
+        return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
     }
 
     @Bean
@@ -54,19 +60,19 @@ public class WebSecurityConfig {
 
         // 기본 설정인 Session 방식은 사용하지 않고 JWT 방식을 사용하기 위한 설정
         http.sessionManagement((sessionManagement) ->
-            sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
         );
 
         http.authorizeHttpRequests((authorizeHttpRequests) ->
-            authorizeHttpRequests
-                .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
-                .requestMatchers("/api/**").permitAll()
-                .requestMatchers(HttpMethod.GET, "/api/**").permitAll()
-                .anyRequest().authenticated() // 그 외 모든 요청 인증처리
+                authorizeHttpRequests
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
+                        .requestMatchers("/api/users/**").permitAll() // '/api/users/'로 시작하는 요청 모두 접근 허가
+                        .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );
 
         // 필터 관리
-        http.addFilterBefore(jwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);
+        http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/sparta/trelloproject/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/trelloproject/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,70 @@
+package com.sparta.trelloproject.common.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.trelloproject.common.api.ApiResponseDto;
+import com.sparta.trelloproject.common.security.UserDetailsImpl;
+import com.sparta.trelloproject.user.dto.AuthRequestDto;
+import com.sparta.trelloproject.user.entity.UserRoleEnum;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j(topic = "로그인 및 JWT 생성")
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final JwtUtil jwtUtil;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+        // 내가 원하는 Url에서 필터가 동작하길 원한다면 setFilterProcessesUrl()로 Url를 설정해줘야 작동함.
+        setFilterProcessesUrl("/api/users/login");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        log.info("로그인 시도");
+        try {
+            AuthRequestDto requestDto = new ObjectMapper().readValue(request.getInputStream(), AuthRequestDto.class);
+
+            return getAuthenticationManager().authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            requestDto.getUserName(),
+                            requestDto.getPassword(),
+                            null
+                    )
+            );
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException {
+        log.info("로그인 성공 및 JWT 생성");
+        String username = ((UserDetailsImpl) authResult.getPrincipal()).getUsername();
+        UserRoleEnum role = ((UserDetailsImpl) authResult.getPrincipal()).getUser().getRole();
+
+        String token = jwtUtil.createToken(username, role);
+        jwtUtil.addJwtToCookie(token, response);
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(new ObjectMapper().writeValueAsString(new ApiResponseDto("로그인 성공", HttpStatus.OK.value())));
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException {
+        log.info("로그인 실패");
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(new ObjectMapper().writeValueAsString(new ApiResponseDto("로그인 실패", HttpStatus.UNAUTHORIZED.value())));
+    }
+}

--- a/src/main/java/com/sparta/trelloproject/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/trelloproject/common/jwt/JwtAuthenticationFilter.java
@@ -63,8 +63,9 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     @Override
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException {
         log.info("로그인 실패");
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        response.getWriter().write(new ObjectMapper().writeValueAsString(new ApiResponseDto("로그인 실패", HttpStatus.UNAUTHORIZED.value())));
+        response.getWriter().write(new ObjectMapper().writeValueAsString(new ApiResponseDto("아이디 또는 비밀번호를 확인해 주세요.", HttpStatus.UNAUTHORIZED.value())));
     }
 }

--- a/src/main/java/com/sparta/trelloproject/common/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/sparta/trelloproject/common/jwt/JwtAuthorizationFilter.java
@@ -1,71 +1,67 @@
 package com.sparta.trelloproject.common.jwt;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sparta.trelloproject.common.api.ApiResponseDto;
 import com.sparta.trelloproject.common.security.UserDetailsServiceImpl;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-
 @Slf4j(topic = "JWT 검증 및 인가")
+@RequiredArgsConstructor
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
     private final UserDetailsServiceImpl userDetailsService;
-    private final ObjectMapper objectMapper;
-
-    public JwtAuthorizationFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService, ObjectMapper objectMapper) {
-        this.jwtUtil = jwtUtil;
-        this.userDetailsService = userDetailsService;
-        this.objectMapper = objectMapper;
-    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        String token = jwtUtil.resolveToken(request);
-
-        if(token != null) {
-            if(!jwtUtil.validateToken(token)){
-                ApiResponseDto responseDto = new ApiResponseDto("토큰이 유효하지 않습니다.", HttpStatus.BAD_REQUEST.value());
-                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-                response.setContentType("application/json; charset=UTF-8");
-                response.getWriter().write(objectMapper.writeValueAsString(responseDto));
+        // 헤더에서 토큰 가져오기
+        String tokenValue = jwtUtil.getTokenFromRequest(request);
+        // 확인
+        if (StringUtils.hasText(tokenValue)) {
+            // JWT 토큰 substring
+            tokenValue = jwtUtil.substringToken(tokenValue);
+            // 검증
+            if (!jwtUtil.validateToken(tokenValue)) {
+                log.error("Token Error");
                 return;
             }
-            Claims info = jwtUtil.getUserInfoFromToken(token);
-            setAuthentication(info.getSubject());
+            // 토큰에서 정보 가져오기
+            Claims info = jwtUtil.getUserInfoFromToken(tokenValue);
+            try {
+                // 인증 처리
+                setAuthentication(info.getSubject());
+            } catch (Exception e) {
+                log.error(e.getMessage());
+                return;
+            }
         }
-
         filterChain.doFilter(request, response);
     }
 
     // 인증 처리
-    public void setAuthentication(String userName) {
+    private void setAuthentication(String username) {
         SecurityContext context = SecurityContextHolder.createEmptyContext();
-        Authentication authentication = createAuthentication(userName);
+        Authentication authentication = createAuthentication(username); // 인증 객체 생성
         context.setAuthentication(authentication);
-        // username -> user 조회 -> userDetails 에 담고 -> authentication의 principal 에 담고
-        // -> securityContent 에 담고 -> SecurityContextHolder 에 담고
-        // -> 이제 @AuthenticationPrincipal 로 조회할 수 있음
         SecurityContextHolder.setContext(context);
     }
 
     // 인증 객체 생성
-    private Authentication createAuthentication(String userName) {
-        UserDetails userDetails = userDetailsService.loadUserByUsername(userName);
+    private Authentication createAuthentication(String username) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 }

--- a/src/main/java/com/sparta/trelloproject/common/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/trelloproject/common/jwt/JwtUtil.java
@@ -4,27 +4,37 @@ import com.sparta.trelloproject.user.entity.UserRoleEnum;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
 
+
+@Slf4j(topic = "JwtUtil")
 @Component
-@RequiredArgsConstructor
 public class JwtUtil {
+    /* 0. JWT 데이터 */
     // Header KEY 값
     public static final String AUTHORIZATION_HEADER = "Authorization";
-    // 사용자 권한 키값. 사용자 권한도 토큰안에 넣어주기 때문에 그때 사용하는 키값
+    // 사용자 권한 값의 KEY
     public static final String AUTHORIZATION_KEY = "auth";
     // Token 식별자
     public static final String BEARER_PREFIX = "Bearer ";
+    // 토큰 만료시간
+    private final long TOKEN_TIME = 60 * 60 * 1000L; // = 60분
 
     @Value("${jwt.secret.key}") // Base64 Encode 한 SecretKey
     private String secretKey;
@@ -40,52 +50,88 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    // header 토큰을 가져오기 Keys.hmacShaKeyFor(bytes);
-    public String resolveToken(HttpServletRequest request) {
-        String bearerToken= request.getHeader(AUTHORIZATION_HEADER);
-        if(StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)){
-            return bearerToken.substring(7);
-        }
-        return null;
-    }
 
+    /* 1. JWT 생성 */
     // 토큰 생성
-    public String createToken(String userName, UserRoleEnum role) {
+    public String createToken(String username, UserRoleEnum role) {
         Date date = new Date();
 
-        // 토큰 만료시간
-        // 60분
-        long TOKEN_TIME = 60 * 60 * 1000L;
         return BEARER_PREFIX +
                 Jwts.builder()
-                        .setSubject(userName) // 사용자 식별자값(ID)
-                        .claim(AUTHORIZATION_KEY, role)
+                        .setSubject(username) // 사용자 식별자값 (ID)
+                        .claim(AUTHORIZATION_KEY, role) // 사용자 권한
                         .setExpiration(new Date(date.getTime() + TOKEN_TIME)) // 만료 시간
                         .setIssuedAt(date) // 발급일
                         .signWith(key, signatureAlgorithm) // 암호화 알고리즘
                         .compact();
     }
 
+
+    /* 2. 생성된 JWT를 Cookie에 저장 */
+    // JWT Cookie에 저장
+    public void addJwtToCookie(String token, HttpServletResponse res) throws IOException {
+        try {
+            // Cookie Value에는 공백이 불가능해서 encoding 진행
+            token = URLEncoder.encode(token, "utf-8").replaceAll("\\+", "%20");
+            Cookie cookie = new Cookie(AUTHORIZATION_HEADER, token); // Name-Value
+            cookie.setPath("/");
+            // Response 객체에 Cookie 추가
+            res.addCookie(cookie);
+        } catch (UnsupportedEncodingException e) {
+            logger.error(e.getMessage());
+            throw new IOException(e.getMessage());
+        }
+    }
+
+    /* 3. Cookie에 들어있던 JWT 토큰을 Substring */
+    // JWT 토큰 substring
+    public String substringToken(String tokenValue) {
+        if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
+            return tokenValue.substring(7);
+        }
+        logger.error("Not Found Token");
+        throw new NullPointerException("Not Found Token");
+    }
+
+    /* 4. JWT 검증 */
     // 토큰 검증
     public boolean validateToken(String token) {
         try {
-            // 토큰의 위변조, 만료 체크
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         } catch (SecurityException | MalformedJwtException | SignatureException e) {
-            logger.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+            log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
         } catch (ExpiredJwtException e) {
-            logger.error("Expired JWT token, 만료된 JWT token 입니다.");
+            log.error("Expired JWT token, 만료된 JWT token 입니다.");
         } catch (UnsupportedJwtException e) {
-            logger.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+            log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
         } catch (IllegalArgumentException e) {
-            logger.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+            log.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
         }
         return false;
     }
 
+    /* 5. JWT에서 사용자 정보 가져오기 */
     // 토큰에서 사용자 정보 가져오기
     public Claims getUserInfoFromToken(String token) {
         return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+
+    // HttpServletRequest 에서 Cookie Value : JWT 가져오기
+    public String getTokenFromRequest(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(AUTHORIZATION_HEADER)) {
+                    try {
+                        // Encode 되어 넘어간 Value를 다시 Decode
+                        return URLDecoder.decode(cookie.getValue(), "UTF-8");
+                    } catch (UnsupportedEncodingException e) {
+                        return null;
+                    }
+                }
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/sparta/trelloproject/common/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/sparta/trelloproject/common/security/UserDetailsServiceImpl.java
@@ -24,7 +24,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String userName) throws UsernameNotFoundException {
         User user = userRepository.findByUserName(userName)
-                .orElseThrow(() -> new UsernameNotFoundException("Not Found " + userName));
+                .orElseThrow(() -> new UsernameNotFoundException("만료된 토큰입니다."));
 
         return new UserDetailsImpl(user);
     }

--- a/src/main/java/com/sparta/trelloproject/common/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/sparta/trelloproject/common/security/UserDetailsServiceImpl.java
@@ -24,7 +24,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String userName) throws UsernameNotFoundException {
         User user = userRepository.findByUserName(userName)
-                .orElseThrow(() -> new UsernameNotFoundException("만료된 토큰입니다."));
+                .orElseThrow(() -> new UsernameNotFoundException("사용자가 존재하지 않습니다."));
 
         return new UserDetailsImpl(user);
     }

--- a/src/main/java/com/sparta/trelloproject/user/controller/UserController.java
+++ b/src/main/java/com/sparta/trelloproject/user/controller/UserController.java
@@ -1,9 +1,9 @@
 package com.sparta.trelloproject.user.controller;
 
 import com.sparta.trelloproject.common.api.ApiResponseDto;
+import com.sparta.trelloproject.common.jwt.JwtUtil;
 import com.sparta.trelloproject.user.dto.AuthRequestDto;
 import com.sparta.trelloproject.user.service.UserService;
-import com.sparta.trelloproject.common.jwt.JwtUtil;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,33 +15,19 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/users")
 public class UserController {
     private final UserService userService;
     private final JwtUtil jwtUtil;
 
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponseDto> sighUp (@RequestBody AuthRequestDto authRequestDto){
+    public ResponseEntity<ApiResponseDto> sighUp(@RequestBody AuthRequestDto authRequestDto) {
 
         try {
             userService.signup(authRequestDto);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(new ApiResponseDto("중복된 Id 입니다.", HttpStatus.BAD_REQUEST.value()));
         }
-        return ResponseEntity.ok().body(new ApiResponseDto("회원가입 성공", HttpStatus.CREATED.value()));
-    }
-
-    @PostMapping("/login")
-    public ResponseEntity<ApiResponseDto> login (@RequestBody AuthRequestDto authRequestDto, HttpServletResponse servletResponse){
-
-        try {
-            userService.login(authRequestDto);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(new ApiResponseDto("회원을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST.value()));
-        }
-
-        servletResponse.addHeader(JwtUtil.AUTHORIZATION_HEADER, jwtUtil.createToken(authRequestDto.getUserName(), authRequestDto.getRole()));
-
-        return ResponseEntity.ok().body(new ApiResponseDto("로그인 성공", HttpStatus.CREATED.value()));
+        return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponseDto("회원가입 성공", HttpStatus.CREATED.value()));
     }
 }

--- a/src/main/java/com/sparta/trelloproject/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/trelloproject/user/repository/UserRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository <User, Long> {
+public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUserName(String userName);
 }

--- a/src/main/java/com/sparta/trelloproject/user/service/UserService.java
+++ b/src/main/java/com/sparta/trelloproject/user/service/UserService.java
@@ -28,19 +28,4 @@ public class UserService {
         User user = new User(userName, password, email, role);
         userRepository.save(user);
     }
-
-    public void login(AuthRequestDto authRequestDto) {
-        String userName = authRequestDto.getUserName();
-        String password = authRequestDto.getPassword();
-
-        //Id 확인
-        User user = userRepository.findByUserName(userName).orElseThrow(
-                () -> new IllegalArgumentException("Id가 틀렸습니다.")
-        );
-
-        //패스워드 확인
-        if (!PasswordEncoder.matches(password, user.getPassword())) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
-        }
-    }
 }


### PR DESCRIPTION
1. 로그인 로직을 Header 에서 토큰을 매번 가져오는 것 보다 로그인 시 자동으로 Cookies 에 할당되어 좀 더 편한 작업 가능
![image](https://github.com/JihyeChu/Trello-Project/assets/133615790/d88ac4d9-a6ad-4ae3-8394-791b4605edca)
자동으로 Cookies 에 로그인 시 마다 매번 갱신 되므로 매번 Header 에서 직접 토큰을 받아올 필요가 없음

2. GlobalControllerAdvice 로 postman 에서도 오류 발생 시 msg와 statusCode 리턴받게 수정
(전) 
![image](https://github.com/JihyeChu/Trello-Project/assets/133615790/5371c389-6919-4917-8ef7-02cfbd4e5718)
statusCode 만 받고 Body 에서는 출력이 되지 않는 부분

(후)
![image](https://github.com/JihyeChu/Trello-Project/assets/133615790/948cfb6a-490a-4c2d-8f8f-1db9b7165a18)
statusCode 도 해당하는 Error 맞게 수정하고, msg 로도 확인할 수 있는 부분

3. 컬럼 CRUD 권한이 필요한 중복 코드 최소화

4. ColorEnum 에 맞지 않는 값을 넣었을 경우 Error 반환과 함께 postman 에서도 확인 가능
(전)
![image](https://github.com/JihyeChu/Trello-Project/assets/133615790/b4a494de-2385-4bdf-a0da-e60ca811d836)
IntelliJ 에서는 오류를 확인할 수 있으나

![image](https://github.com/JihyeChu/Trello-Project/assets/133615790/b92d2249-65ea-4e83-a0d1-82371dbeda2e)
postman 에서는 확인이 불가능 했음

(후)
![image](https://github.com/JihyeChu/Trello-Project/assets/133615790/b1a335eb-67b7-4d09-b03a-ec83d1d9c59f)
지정된 색을 알려줄 지, 아니면 이렇게 반환할 지에 대해서는 추후 토론 후 수정 가능

5. 로그인 실패 시 postman 에서도 확인 가능 및 상태 코드 변경 (200 -> 401)
> 쿠키가 존재할 땐 구현 불가, 쿠키가 없을 땐 확인 가능
![image](https://github.com/JihyeChu/Trello-Project/assets/133615790/b241fd84-6c22-4417-b2f8-1492be0eac7e)

6. 보드 내 컬럼 이동 기능 구현
![image](https://github.com/JihyeChu/Trello-Project/assets/133615790/472fbcf5-6f62-4b33-a2a0-02f1e07c2342)
컬럼 조회 시 position 을 추가해 기본 1024에 컬럼이 추가될 수록 1024가 더해지도록 구현

1번 컬럼을 3번으로 변경
![image](https://github.com/JihyeChu/Trello-Project/assets/133615790/528a9342-019d-467f-a3d6-707d2ae2b862)
주소창에서 http://localhost:8080/api/boards/1/columns/{columnId}/order -> columnId : 바꾸고 싶은 컬럼
body 에서 selectIndex : 바꾸고 싶은 자리 

![image](https://github.com/JihyeChu/Trello-Project/assets/133615790/2c4e4ad0-89b8-4518-aa43-30f442f3412f)
따라서 1번 컬럼을 3번으로 옮기고싶다 -> 1, 2, 3 의 순서를 2, 3 ,1 의 순서로 변경
position 바꾸고싶은 컬럼의 position 과 바꿀 컬럼의 position 을 더한 후 2로 나누면 새로 생길 4번의 컬럼의 4096 보다 낮기 떄문에 3번의 자리에서 유지 가능

7. dto 수정 및 컬럼 조회 시 position 오름차순으로 정렬
![image](https://github.com/JihyeChu/Trello-Project/assets/133615790/6faf7aed-1f98-47ff-a3b2-3a82d60f5e5b)
dto 수정으로 position 숨김처리

8. 순서 변경 시 api 수정
주소창에서 http://localhost:8080/api/boards/1/columns/{columnId}/order -> columnId : 바꾸고 싶은 컬럼
기존의 방법에서 ColumnMoveDto 수정으로 인해
![image](https://github.com/JihyeChu/Trello-Project/assets/133615790/a0e459e2-8e20-44b2-9bea-44743e445d57)
바꾸고 싶은 컬럼(selectColumn), 변경할 위치(selectIndex) 설정
위의 상황에서 컬럼3 의 위치를 마지막으로 바꾸려면 selectColumn 을 3, selectIndex 를 4로 바꾸면 예측 결과값은 4 2 1 3
![image](https://github.com/JihyeChu/Trello-Project/assets/133615790/d4f05803-eb52-4063-ae92-2147f06b05cc)
정상작동 되는 것을 확인할 수 있음

